### PR TITLE
COUNT queries can be very slow

### DIFF
--- a/NodeinfoPlugin.php
+++ b/NodeinfoPlugin.php
@@ -8,33 +8,173 @@ class NodeinfoPlugin extends Plugin
 {
     const VERSION = '0.0.1';
 
-    function onRouterInitialized($m)
+    public function onRouterInitialized($m)
     {
         $m->connect(
-            '.well-known/nodeinfo', array(
-                    'action' => 'nodeinfojrd'
-                )
+            '.well-known/nodeinfo',
+            array(
+                'action' => 'nodeinfojrd'
+            )
         );
 
         $m->connect(
-            'main/nodeinfo/2.0', array(
-                    'action' => 'nodeinfo_2_0'
-                )
+            'main/nodeinfo/2.0',
+            array(
+                'action' => 'nodeinfo_2_0'
+            )
         );
 
         return true;
     }
 
-    function onPluginVersion(array &$versions)
+    /**
+     * Make sure necessary tables are filled out.
+     *
+     * @return boolean hook true
+     */
+    public function onCheckSchema()
     {
-        $versions[] = array('name' => 'Nodeinfo',
-                            'version' => self::VERSION,
-                            'author' => 'chimo',
-                            'homepage' => 'https://github.com/chimo/gs-nodeinfo',
-                            'description' =>
+        // Ensure schema
+        $schema = Schema::get();
+        $schema->ensureTable('usage_stats', Usage_stats::schemaDef());
+
+        // Ensure default rows
+        if (Usage_stats::getKV('type', 'users') == null) {
+            $us = new Usage_stats();
+            $us->type = 'users';
+            $us->insert();
+        }
+
+        if (Usage_stats::getKV('type', 'posts') == null) {
+            $us = new Usage_stats();
+            $us->type = 'posts';
+            $us->insert();
+        }
+
+        if (Usage_stats::getKV('type', 'comments') == null) {
+            $us = new Usage_stats();
+            $us->type = 'comments';
+            $us->insert();
+        }
+
+        return true;
+    }
+
+    /**
+     * Increment notices/replies counter
+     *
+     * @return boolean hook flag
+     * @author Diogo Cordeiro <diogo@fc.up.pt>
+     */
+    public function onStartNoticeDistribute($notice)
+    {
+        assert($notice->id > 0);        // Ignore if not a valid notice
+
+        $profile = $notice->getProfile();
+
+        if (!$profile->isLocal()) {
+            return true;
+        }
+
+        // Ignore for activity/non-post-verb notices
+        if (method_exists('ActivityUtils', 'compareVerbs')) {
+            $is_post_verb = ActivityUtils::compareVerbs(
+                $notice->verb,
+                [ActivityVerb::POST]
+            );
+        } else {
+            $is_post_verb = ($notice->verb == ActivityVerb::POST ? true : false);
+        }
+        if ($notice->source == 'activity' || !$is_post_verb) {
+            return true;
+        }
+
+        // Is a reply?
+        if ($notice->reply_to) {
+            $us = Usage_stats::getKV('type', 'comments');
+            $us->count += 1;
+            $us->update();
+            return true;
+        }
+
+        // Is an Announce?
+        if ($notice->isRepeat()) {
+            return true;
+        }
+
+        $us = Usage_stats::getKV('type', 'posts');
+        $us->count += 1;
+        $us->update();
+
+        // That was it
+        return true;
+    }
+
+    /**
+     * Decrement notices/replies counter
+     *
+     * @return boolean hook flag
+     * @author Diogo Cordeiro <diogo@fc.up.pt>
+     */
+    public function onStartDeleteOwnNotice($user, $notice)
+    {
+        $profile = $user->getProfile();
+
+        // Only count local notices
+        if (!$profile->isLocal()) {
+            return true;
+        }
+
+        if ($notice->reply_to) {
+            $us = Usage_stats::getKV('type', 'comments');
+            $us->count -= 1;
+            $us->update();
+            return true;
+        }
+
+        $us = Usage_stats::getKV('type', 'posts');
+        $us->count -= 1;
+        $us->update();
+        return true;
+    }
+
+    /**
+     * Increment users counter
+     *
+     * @return boolean hook flag
+     * @author Diogo Cordeiro <diogo@fc.up.pt>
+     */
+    public function onEndRegistrationTry()
+    {
+        $us = Usage_stats::getKV('type', 'users');
+        $us->count += 1;
+        $us->update();
+        return true;
+    }
+
+    /**
+     * Decrement users counter
+     *
+     * @return boolean hook flag
+     * @author Diogo Cordeiro <diogo@fc.up.pt>
+     */
+    public function onEndDeleteUser()
+    {
+        $us = Usage_stats::getKV('type', 'users');
+        $us->count -= 1;
+        $us->update();
+        return true;
+    }
+
+    public function onPluginVersion(array &$versions)
+    {
+        $versions[] = ['name' => 'Nodeinfo',
+            'version' => self::VERSION,
+            'author' => 'chimo',
+            'homepage' => 'https://github.com/chimo/gs-nodeinfo',
+            'description' =>
                             // TRANS: Plugin description.
-                            _m('')); // TODO
+                            _m('Plugin that presents basic instance information using the NodeInfo standard.')]; // TODO
         return true;
     }
 }
-

--- a/actions/nodeinfo_2_0.php
+++ b/actions/nodeinfo_2_0.php
@@ -17,14 +17,14 @@ class Nodeinfo_2_0Action extends ApiAction
         $this->showNodeInfo();
     }
 
-    function getActivePluginList()
+    public function getActivePluginList()
     {
         $pluginversions = array();
         $plugins = array();
 
         Event::handle('PluginVersion', array(&$pluginversions));
 
-        foreach($pluginversions as $plugin) {
+        foreach ($pluginversions as $plugin) {
             $plugins[strtolower($plugin['name'])] = 1;
         }
 
@@ -36,115 +36,8 @@ class Nodeinfo_2_0Action extends ApiAction
      * but GNU social doesn't keep track of when users last logged in, so let's return
      * the number of users that 'posted at least once', I guess.
      */
-    function getActiveUsers($days)
-    {
-        $notices = new Notice();
-        $notices->joinAdd(array('profile_id', 'user:id'));
-        $notices->whereAdd('notice.created >= NOW() - INTERVAL ' . $days . ' DAY');
 
-        $activeUsersCount = $notices->count('distinct profile_id');
-
-        return $activeUsersCount;
-    }
-
-    function getRegistrationsStatus()
-    {
-        $areRegistrationsClosed = (common_config('site', 'closed')) ? true : false;
-        $isSiteInviteOnly = (common_config('site', 'inviteonly')) ? true : false;
-
-        return !($areRegistrationsClosed || $isSiteInviteOnly);
-    }
-
-    function getUserCount()
-    {
-        $users = new User();
-        $userCount = $users->count();
-
-        return $userCount;
-    }
-
-    function getPostCount()
-    {
-        $notices = new Notice();
-        $notices->is_local = Notice::LOCAL_PUBLIC;
-        $notices->whereAdd('reply_to IS NULL');
-        $noticeCount = $notices->count();
-
-        return $noticeCount;
-    }
-
-    function getCommentCount()
-    {
-        $notices = new Notice();
-        $notices->is_local = Notice::LOCAL_PUBLIC;
-        $notices->whereAdd('reply_to IS NOT NULL');
-        $commentCount = $notices->count();
-
-        return $commentCount;
-    }
-
-    function getProtocols()
-    {
-        $oStatusEnabled = array_key_exists('ostatus', $this->plugins);
-        $xmppEnabled = (array_key_exists('xmpp', $this->plugins) && common_config('xmpp', 'enabled')) ? true : false;
-        $protocols = array();
-
-        if (Event::handle('StartNodeInfoProtocols', array(&$protocols))) {
-            // Until the OStatus and XMPP plugins handle this themselves,
-            // try to figure out if they're enabled ourselves.
-
-            if ($oStatusEnabled) {
-                $protocols[] = 'ostatus';
-            }
-
-            if ($xmppEnabled) {
-                $protocols[] = 'xmpp';
-            }
-        }
-        Event::handle('EndNodeInfoProtocols', array(&$protocols));
-
-        return $protocols;
-    }
-
-    function getInboundServices()
-    {
-        // FIXME: Are those always on?
-        $inboundServices = array('atom1.0', 'rss2.0');
-
-        if (array_key_exists('twitterbridge', $this->plugins) && $config['twitterimport']['enabled']) {
-            $inboundServices[] = 'twitter';
-        }
-
-        if (array_key_exists('ostatus', $this->plugins)) {
-            $inboundServices[] = 'gnusocial';
-        }
-
-        return $inboundServices;
-    }
-
-    function getOutboundServices()
-    {
-        $xmppEnabled = (array_key_exists('xmpp', $this->plugins) && common_config('xmpp', 'enabled')) ? true : false;
-
-        // FIXME: Are those always on?
-        $outboundServices = array('atom1.0', 'rss2.0');
-
-        if (array_key_exists('twitterbridge', $this->plugins)) {
-            $outboundServices[] = 'twitter';
-        }
-
-        if (array_key_exists('ostatus', $this->plugins)) {
-            $outboundServices[] = 'gnusocial';
-        }
-
-        if ($xmppEnabled) {
-            $outboundServices[] = 'xmpp';
-        }
-
-        return $outboundServices;
-    }
-
-    function showNodeInfo()
+    public function showNodeInfo()
     {
         $openRegistrations = $this->getRegistrationsStatus();
         $userCount = $this->getUserCount();
@@ -193,5 +86,104 @@ class Nodeinfo_2_0Action extends ApiAction
         print $json;
         $this->endDocument('json');
     }
-}
 
+    public function getRegistrationsStatus()
+    {
+        $areRegistrationsClosed = (common_config('site', 'closed')) ? true : false;
+        $isSiteInviteOnly = (common_config('site', 'inviteonly')) ? true : false;
+
+        return !($areRegistrationsClosed || $isSiteInviteOnly);
+    }
+
+    public function getUserCount()
+    {
+        $users = new Usage_stats();
+        $userCount = $users->getUserCount();
+
+        return $userCount;
+    }
+
+    public function getPostCount()
+    {
+        $posts = new Usage_stats();
+        $postCount = $posts->getPostCount();
+
+        return $postCount;
+    }
+
+    public function getCommentCount()
+    {
+        $comments = new Usage_stats();
+        $commentCount = $comments->getCommentCount();
+
+        return $commentCount;
+    }
+
+    public function getActiveUsers($days)
+    {
+        $notices = new Notice();
+        $notices->joinAdd(array('profile_id', 'user:id'));
+        $notices->whereAdd('notice.created >= NOW() - INTERVAL ' . $days . ' DAY');
+
+        $activeUsersCount = $notices->count('distinct profile_id');
+
+        return $activeUsersCount;
+    }
+
+    public function getProtocols()
+    {
+        $oStatusEnabled = array_key_exists('ostatus', $this->plugins);
+        $xmppEnabled = (array_key_exists('xmpp', $this->plugins) && common_config('xmpp', 'enabled')) ? true : false;
+        $protocols = array();
+        if (Event::handle('StartNodeInfoProtocols', array(&$protocols))) {
+            // Until the OStatus and XMPP plugins handle this themselves,
+            // try to figure out if they're enabled ourselves.
+            if ($oStatusEnabled) {
+                $protocols[] = 'ostatus';
+            }
+            if ($xmppEnabled) {
+                $protocols[] = 'xmpp';
+            }
+        }
+        Event::handle('EndNodeInfoProtocols', array(&$protocols));
+        return $protocols;
+    }
+
+    public function getInboundServices()
+    {
+        // FIXME: Are those always on?
+        $inboundServices = array('atom1.0', 'rss2.0');
+
+        if (array_key_exists('twitterbridge', $this->plugins) && $config['twitterimport']['enabled']) {
+            $inboundServices[] = 'twitter';
+        }
+
+        if (array_key_exists('ostatus', $this->plugins)) {
+            $inboundServices[] = 'gnusocial';
+        }
+
+        return $inboundServices;
+    }
+
+    public function getOutboundServices()
+    {
+        $xmppEnabled = (array_key_exists('xmpp', $this->plugins) && common_config('xmpp', 'enabled')) ? true : false;
+
+        // FIXME: Are those always on?
+        $outboundServices = array('atom1.0', 'rss2.0');
+
+        if (array_key_exists('twitterbridge', $this->plugins)) {
+            $outboundServices[] = 'twitter';
+        }
+
+        if (array_key_exists('ostatus', $this->plugins)) {
+            $outboundServices[] = 'gnusocial';
+        }
+
+        if ($xmppEnabled) {
+            $outboundServices[] = 'xmpp';
+        }
+
+        return $outboundServices;
+    }
+}

--- a/actions/nodeinfojrd.php
+++ b/actions/nodeinfojrd.php
@@ -12,8 +12,6 @@ class NodeinfoJRDAction extends XrdAction
 
     protected function setXRD()
     {
-        $this->xrd->links[] = new XML_XRD_Element_link(self::NODEINFO_2_0_REL,  common_local_url('nodeinfo_2_0'));
+        $this->xrd->links[] = new XML_XRD_Element_link(self::NODEINFO_2_0_REL, common_local_url('nodeinfo_2_0'));
     }
 }
-
-

--- a/classes/Usage_stats.php
+++ b/classes/Usage_stats.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * GNU social - a federating social network
+ *
+ * LICENCE: This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+if (!defined('GNUSOCIAL')) {
+    exit(1);
+}
+
+/**
+ * Table Definition for Usage_stats
+ */
+class Usage_stats extends Managed_DataObject
+{
+    ###START_AUTOCODE
+    /* the code below is auto generated do not remove the above tag */
+
+    public $__table = 'usage_stats';         // table name
+    public $type;                            // varchar(191)  unique_key   not 255 because utf8mb4 takes more space
+    public $count;                           // int(4)
+    public $modified;                        // timestamp()   not_null default_CURRENT_TIMESTAMP
+
+    /* the code above is auto generated do not remove the tag below */
+    ###END_AUTOCODE
+
+    public static function schemaDef()
+    {
+        return [
+            'description' => 'node stats',
+            'fields' => [
+                'type' => ['type' => 'varchar', 'length' => 191, 'description' => 'Type of countable entity'],
+                'count' => ['type' => 'int', 'size' => 'int', 'default' => 0, 'description' => 'Number of entities of this type'],
+
+                'modified' => ['type' => 'datetime', 'not null' => true, 'default' => 'CURRENT_TIMESTAMP', 'description' => 'date this record was modified'],
+            ],
+            'primary key' => ['type'],
+            'unique keys' => [
+                'usage_stats_key' => ['type'],
+            ],
+            'indexes' => [
+                'user_stats_idx' => ['type'],
+            ],
+        ];
+    }
+
+    public function getUserCount()
+    {
+        return intval(Usage_stats::getKV('type', 'users')->count);
+    }
+
+    public function getPostCount()
+    {
+        return intval(Usage_stats::getKV('type', 'posts')->count);
+    }
+
+    public function getCommentCount()
+    {
+        return intval(Usage_stats::getKV('type', 'comments')->count);
+    }
+}

--- a/scripts/fix_stats.php
+++ b/scripts/fix_stats.php
@@ -1,0 +1,117 @@
+#!/usr/bin/env php
+<?php
+/**
+ * GNU social - a federating social network
+ *
+ * LICENCE: This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @category  Plugin
+ * @package   GNUsocial
+ * @copyright 2018 Free Software Foundation http://fsf.org
+ * @license   http://www.fsf.org/licensing/licenses/agpl-3.0.html GNU Affero General Public License version 3.0
+ * @link      https://www.gnu.org/software/social/
+ */
+
+define('INSTALLDIR', realpath(__DIR__ . '/../../..'));
+
+$longoptions = ['type='];
+
+$helptext = <<<END_OF_HELP
+fix_stats.php [options]
+Counts the stats from database values and updates the table.
+
+    --type          Optional flag to specify the type to update. They all are updated by default.
+                       Type: can be 'users', 'posts' or 'comments'. Or 'all', to update all the types.
+
+END_OF_HELP;
+
+require_once INSTALLDIR . '/scripts/commandline.inc';
+
+$valid_types = ['all', 'users', 'posts', 'comments'];
+
+$verbose = have_option('v', 'verbose');
+
+$type_to_fix = get_option_value('type');
+if (!in_array($type_to_fix, $valid_types)) {
+    echo "You must provide a valid type!\n\n";
+    show_help();
+    exit(1);
+}
+
+if ($verbose) {
+    echo "Started.\n\n";
+}
+
+if ($type_to_fix == 'all' || $type_to_fix == 'users') {
+    if ($verbose) {
+        echo "[+] Updating Users stats...\n";
+    }
+    $us = Usage_stats::getKV('users');
+    $us->count = getUserCount();
+    $us->update();
+}
+
+if ($type_to_fix == 'all' || $type_to_fix == 'posts') {
+    if ($verbose) {
+        echo "[+] Updating Posts stats...\n";
+    }
+    $us = Usage_stats::getKV('posts');
+    $us->count = getPostCount();
+    $us->update();
+}
+
+if ($type_to_fix == 'all' || $type_to_fix == 'comments') {
+    if ($verbose) {
+        echo "[+] Updating Comments stats...\n";
+    }
+    $us = Usage_stats::getKV('comments');
+    $us->count = getCommentCount();
+    $us->update();
+}
+
+if ($verbose) {
+    echo "\nDONE.\n";
+}
+
+/*
+ * Counting functions
+ */
+
+function getUserCount()
+{
+    $users = new User();
+    $userCount = $users->count();
+
+    return $userCount;
+}
+
+function getPostCount()
+{
+    $notices = new Notice();
+    $notices->is_local = Notice::LOCAL_PUBLIC;
+    $notices->whereAdd('reply_to IS NULL');
+    $noticeCount = $notices->count();
+
+    return $noticeCount;
+}
+
+function getCommentCount()
+{
+    $notices = new Notice();
+    $notices->is_local = Notice::LOCAL_PUBLIC;
+    $notices->whereAdd('reply_to IS NOT NULL');
+    $commentCount = $notices->count();
+
+    return $commentCount;
+}


### PR DESCRIPTION
As in https://notabug.org/diogo/gnu-social/commit/586fb5a5175d7a10f5f78dd026434e48202e5451

Some context from #social@irc.freenode.org:

```
<XRevan86> > I've added chimo's Nodeinfo plugin as a default plugin on GS
<XRevan86> diogo: Heavy queries is why ldavg doesn't have it.
<dansup> who runs loadaverage
<XRevan86> dansup: I do.
<XRevan86> dansup: Unless you mean hosting, that's being done by maiyannah, and the domain is owned by pztrn
<aab> up201705417, dansup: good idea. I've had Nodeinfo enabled for a long time... don't know what "heavy queries" mean in this context... Too many connections?
<TakinOver> aab: I think heavy queries probably refers to its database usage. LoadAverage isn't a 2-3 active users instance.
<aab> ok, but... with chimo's plugin you get to show general info about your node, not about every single user, right?
<aab> i mean, look at "https://khp.ignorelist.com/main/nodeinfo/2.0". Isn't the same if i had 3000 users?
<TakinOver> I haven't tried chimo's plugin yet. Is it anything like pztrn's old gstools plugin?
<aab> https://github.com/chimo/gs-nodeinfo
<aab> i don't know about pztrn, sorry...
<aab> i installed because it seems to be a "standarized" way to identifiy your node to other nodes on federation
<aab> and appear on https://fediverse.network/, to show GS is not dead XD
<TakinOver> fediverse.network seems to try lots of different ways to identify and summarize. When they first appeared in the logs, I almost blocked them because there were so many different requests and they happened so frequently.
<diogo> TakinOver: yup, they are a bit abusive indeed...
<aab> ah, ok. I saw a request per day, maybe they changed it by the time i installed the plugin...
<aab> i guess you meant this https://github.com/andstatus/andstatus/issues/84
<TakinOver> aab: Yes, the gstools plugin worked with gstools.org, but both are currently abandoned.
<aab> ok
<XRevan86> I suppose I should give https://code.chromic.org/chimo/gs-nodeinfo another chance, that way I'll have something more concrete to show.
<XRevan86> diogo: Enabled it. Brace yourselves
<aab> so... it depends on the number of accounts? Or what else?
<XRevan86> > SELECT count(notice.uri) as DATAOBJECT_NUM FROM notice WHERE ( reply_to IS NULL ) AND ( notice.is_local = 1 ):
<aab> ah, ok, number of notices
<XRevan86> aab: Basically, ldavg has too many notices for its own good :)
<diogo> it does run... 5 queries in the metadata section
<diogo> let me see how to fix that, one sec...
<XRevan86> even though it counts only local ones, it has to comb through all of them
<xmpp-gnu> ***XRevan86 terminates the plugin
<aab> sorry if i miss something, i'm trying to understand: so, you are saying, every query of nodeinfo counts all notices on the node?
<aab> every time?
<XRevan86> aab: It looks that way.
<aab> well, i have no programming skills, so maybe this is dumb, but... Shouldn't database be aware of the number of notices it has in every moment, so it doesn't have to recount on every query?
<xmpp-gnu> [colegota] https://bin.disroot.org/?d7643214e9918ce5#vTkKuyfrmmL3D2p2f7c7cHN4oXfHc5FKocMldC6m16w=
<xmpp-gnu> [colegota] A collection of log entries with "gnusocial"
<diogo> aab: it actually depends in the database engine, some do store, others don't, the one GS is using (innoDB) doesn't
<diogo> aab: https://www.percona.com/blog/2006/12/01/count-for-innodb-tables/
<diogo> also note that there are some constraints like "notice has to be local"
<diogo> so, it really has to go through all of them
<diogo> in order to maintain statistics in a performant way we have to create counters in GS
<aab> ok... so i haven't noticed a great impact because of low number of notices... thanks!
<XRevan86> https://code.chromic.org/chimo/gs-nodeinfo/src/commit/6ee5c3eb6d2aad0aa321d6aff534e4ed5a5a50ed/actions/nodeinfo_2_0.php#L66
<XRevan86> Actually… it counts it twice :)
<XRevan86> first notices, then replies
<XRevan86> in two separate queries
<aab> 😲
<XRevan86> diogo: I wonder if it's possible to make $notices->count(); count on id's instead of uri's in the plugin. Then notice_created_id_is_local_idx applies and such a query only takes 5 minutes instead of… a lot, it hasn't finished yet
<diogo> 5 minutes already is a lot
<diogo> I was creating a table to keep the counts...
<XRevan86> it is still going!
<XRevan86> I think it's already half an hour
<diogo> that's a really huge database
<XRevan86> diogo: 9 million notices in total
<XRevan86> Maybe if I create an index just for nodeinfo…
<XRevan86> CREATE INDEX notice_uri_replyto_is_local_idx ON notice (uri, reply_to, is_local); is going to take a bit of time :)
<diogo> it will probably help, but I still think it would be better to have this answer in O(1)
<XRevan86> diogo: Well, I'm just curious how much it'll take.
<diogo> you need the value anyway so, go for it :)
<XRevan86> hm, it affects the website…
<XRevan86> ugh, I guess I'll wait
<XRevan86> though whatever
```

